### PR TITLE
Pass ignore.Matcher to FSWatcher to filter filesystem events

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -187,7 +187,7 @@ func (f *rwFolder) Serve() {
 	var prevIgnoreHash string
 
 	fswatcher.Tempnamer = defTempNamer
-	fsWatcher := fswatcher.NewFsWatcher(f.dir)
+	fsWatcher := fswatcher.NewFsWatcher(f.dir, f.model.folderIgnores[f.folderID])
 	fsWatchChan, err := fsWatcher.StartWatchingFilesystem()
 	if err != nil {
 		l.Warnln(err)
@@ -220,9 +220,11 @@ func (f *rwFolder) Serve() {
 			if newHash := curIgnores.Hash(); newHash != prevIgnoreHash {
 				// The ignore patterns have changed. We need to re-evaluate if
 				// there are files we need now that were ignored before.
-				l.Debugln(f, "ignore patterns have changed, resetting prevVer")
+				l.Debugln(f, "ignore patterns have changed,",
+					"resetting prevVer and adapting FsWatcher")
 				prevSec = 0
 				prevIgnoreHash = newHash
+				fsWatcher.UpdateIgnores(curIgnores)
 			}
 
 			// RemoteSequence() is a fast call, doesn't touch the database.


### PR DESCRIPTION
This adds the member `ignores` to the FsEvent struct such that it can be passed to `scanner.IsIgnoredPath`. To update this when the ".stignore" file changes I added an exported function as it seemed cleaner than exporting `ignores` directly.