### PR TITLE
Prepend log messages with folderID

### DIFF
--- a/lib/fswatcher/fswatcher.go
+++ b/lib/fswatcher/fswatcher.go
@@ -40,6 +40,7 @@ type FsWatcher struct {
 	inProgress            map[string]struct{}
 	ignores               *ignore.Matcher
 	ignoresLock           sync.RWMutex
+	folderID              string
 }
 
 const (
@@ -47,7 +48,7 @@ const (
 	fastNotifyDelay = time.Duration(500) * time.Millisecond
 )
 
-func NewFsWatcher(folderPath string, ignores *ignore.Matcher) *FsWatcher {
+func NewFsWatcher(folderPath string, ignores *ignore.Matcher, folderID string) *FsWatcher {
 	return &FsWatcher{
 		folderPath:            folderPath,
 		notifyModelChan:       nil,
@@ -59,11 +60,12 @@ func NewFsWatcher(folderPath string, ignores *ignore.Matcher) *FsWatcher {
 		inProgress:            make(map[string]struct{}),
 		ignores:               ignores,
 		ignoresLock:           sync.NewRWMutex(),
+		folderID:              folderID,
 	}
 }
 
 func (watcher *FsWatcher) StartWatchingFilesystem() (<-chan FsEventsBatch, error) {
-	fsEventChan, err := setupNotifications(watcher.folderPath)
+	fsEventChan, err := watcher.setupNotifications()
 	if err == nil {
 		watcher.WatchingFs = true
 		watcher.fsEventChan = fsEventChan
@@ -76,14 +78,14 @@ func (watcher *FsWatcher) StartWatchingFilesystem() (<-chan FsEventsBatch, error
 
 var maxFiles = 512
 
-func setupNotifications(path string) (chan notify.EventInfo, error) {
+func (watcher *FsWatcher) setupNotifications() (chan notify.EventInfo, error) {
 	c := make(chan notify.EventInfo, maxFiles)
-	if err := notify.Watch(filepath.Join(path, "..."), c, notify.All); err != nil {
+	if err := notify.Watch(filepath.Join(watcher.folderPath, "..."), c, notify.All); err != nil {
 		notify.Stop(c)
 		close(c)
-		return nil, interpretNotifyWatchError(err, path)
+		return nil, interpretNotifyWatchError(err, watcher.folderPath)
 	}
-	l.Debugf("Setup filesystem notification for %s", path)
+	watcher.debugf("Setup filesystem notification for %s", watcher.folderPath)
 	return c, nil
 }
 
@@ -131,7 +133,7 @@ func isSubpath(path string, folderPath string) bool {
 
 func (watcher *FsWatcher) resetNotifyTimerIfNeeded() {
 	if watcher.notifyTimerNeedsReset {
-		l.Debugf("Resetting notifyTimer to %#v\n", watcher.notifyDelay)
+		watcher.debugf("Resetting notifyTimer to %#v\n", watcher.notifyDelay)
 		watcher.notifyTimer.Reset(watcher.notifyDelay)
 		watcher.notifyTimerNeedsReset = false
 	}
@@ -140,7 +142,7 @@ func (watcher *FsWatcher) resetNotifyTimerIfNeeded() {
 func (watcher *FsWatcher) speedUpNotifyTimer() {
 	if watcher.notifyDelay != fastNotifyDelay {
 		watcher.notifyDelay = fastNotifyDelay
-		l.Debugf("Speeding up notifyTimer to %#v\n", fastNotifyDelay)
+		watcher.debugf("Speeding up notifyTimer to %#v\n", fastNotifyDelay)
 		watcher.notifyTimerNeedsReset = true
 	}
 }
@@ -148,14 +150,14 @@ func (watcher *FsWatcher) speedUpNotifyTimer() {
 func (watcher *FsWatcher) slowDownNotifyTimer() {
 	if watcher.notifyDelay != slowNotifyDelay {
 		watcher.notifyDelay = slowNotifyDelay
-		l.Debugf("Slowing down notifyTimer to %#v\n", watcher.notifyDelay)
+		watcher.debugf("Slowing down notifyTimer to %#v\n", watcher.notifyDelay)
 		watcher.notifyTimerNeedsReset = true
 	}
 }
 
 func (watcher *FsWatcher) storeFsEvent(event *FsEvent) {
 	if watcher.pathInProgress(event.path) {
-		l.Debugf("Skipping notification for finished path: %s\n",
+		watcher.debugf("Skipping notification for finished path: %s\n",
 			event.path)
 	} else {
 		watcher.fsEvents[event.path] = event
@@ -165,7 +167,7 @@ func (watcher *FsWatcher) storeFsEvent(event *FsEvent) {
 func (watcher *FsWatcher) actOnTimer() {
 	watcher.notifyTimerNeedsReset = true
 	if len(watcher.fsEvents) > 0 {
-		l.Debugf("Notifying about %d fs events\n", len(watcher.fsEvents))
+		watcher.debugf("Notifying about %d fs events\n", len(watcher.fsEvents))
 		watcher.notifyModelChan <- watcher.fsEvents
 	} else {
 		watcher.slowDownNotifyTimer()
@@ -207,6 +209,10 @@ func (watcher *FsWatcher) UpdateIgnores(ignores *ignore.Matcher) {
 	watcher.ignoresLock.Lock()
 	watcher.ignores = ignores
 	watcher.ignoresLock.Unlock()
+}
+
+func (watcher *FsWatcher) debugf(text string, vals ...interface{}) {
+	l.Debugf(watcher.folderID + ": " + text, vals...)
 }
 
 func (batch FsEventsBatch) GetPaths() []string {

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -187,7 +187,7 @@ func (f *rwFolder) Serve() {
 	var prevIgnoreHash string
 
 	fswatcher.Tempnamer = defTempNamer
-	fsWatcher := fswatcher.NewFsWatcher(f.dir, f.model.folderIgnores[f.folderID])
+	fsWatcher := fswatcher.NewFsWatcher(f.dir, f.model.folderIgnores[f.folderID], f.folderID)
 	fsWatchChan, err := fsWatcher.StartWatchingFilesystem()
 	if err != nil {
 		l.Warnln(err)


### PR DESCRIPTION
For debugging it helps a lot to know which folder a message is about. So this prepends the folder ID to every log message within an fswatcher instance.