### PR TITLE
Don't install watches on ignored files and update notify

### DIFF
--- a/lib/fswatcher/fswatcher.go
+++ b/lib/fswatcher/fswatcher.go
@@ -85,7 +85,12 @@ func (watcher *FsWatcher) StartWatchingFilesystem() (<-chan FsEventsBatch, error
 
 func (watcher *FsWatcher) setupNotifications() (chan notify.EventInfo, error) {
 	c := make(chan notify.EventInfo, maxFiles)
-	if err := notify.Watch(filepath.Join(watcher.folderPath, "..."), c, notify.All); err != nil {
+	absShouldIgnore := func(absPath string) bool {
+		relPath, _ := filepath.Rel(watcher.folderPath, absPath)
+		return watcher.ignores.ShouldIgnore(relPath)
+	}
+	if err := notify.WatchWithFilter(filepath.Join(watcher.folderPath, "..."),
+		c, absShouldIgnore, notify.All); err != nil {
 		notify.Stop(c)
 		close(c)
 		return nil, interpretNotifyWatchError(err, watcher.folderPath)

--- a/vendor/github.com/zillode/notify/appveyor.yml
+++ b/vendor/github.com/zillode/notify/appveyor.yml
@@ -11,7 +11,6 @@ environment:
 
 install:
  - go version
- - go get golang.org/x/tools/cmd/vet
  - go get -v -t ./...
 
 build_script:

--- a/vendor/github.com/zillode/notify/node.go
+++ b/vendor/github.com/zillode/notify/node.go
@@ -6,6 +6,7 @@ package notify
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -70,7 +71,7 @@ Traverse:
 		case errSkip:
 			continue Traverse
 		default:
-			return err
+			return fmt.Errorf("error while traversing %q: %v", nd.Name, err)
 		}
 		// TODO(rjeczalik): tolerate open failures - add failed names to
 		// AddDirError and notify users which names are not added to the tree.

--- a/vendor/github.com/zillode/notify/notify.go
+++ b/vendor/github.com/zillode/notify/notify.go
@@ -61,7 +61,16 @@ var defaultTree = newTree()
 // e.g. use persistant paths like %userprofile% or watch additionally parent
 // directory of a recursive watchpoint in order to receive delete events for it.
 func Watch(path string, c chan<- EventInfo, events ...Event) error {
-	return defaultTree.Watch(path, c, events...)
+	return defaultTree.Watch(path, c, nil, events...)
+}
+
+// This function works the same way as Watch. In addition it does not watch
+// files or directories based on the return value of the argument function
+// doNotWatch. Given a path as argument doNotWatch should return true if the
+// file or directory should not be watched.
+func WatchWithFilter(path string, c chan<- EventInfo,
+	doNotWatch func(string) bool, events ...Event) error {
+	return defaultTree.Watch(path, c, doNotWatch, events...)
 }
 
 // Stop removes all watchpoints registered for c. All underlying watches are

--- a/vendor/github.com/zillode/notify/testing_test.go
+++ b/vendor/github.com/zillode/notify/testing_test.go
@@ -768,17 +768,21 @@ func (n *N) Close() error {
 	return nil
 }
 
+func dummyDoNotWatch(path string) bool {
+	return false
+}
+
 func (n *N) Watch(path string, c chan<- EventInfo, events ...Event) {
 	UpdateWait() // we need to wait on Windows because of its asynchronous watcher.
 	path = filepath.Join(n.w.root, path)
-	if err := n.tree.Watch(path, c, events...); err != nil {
+	if err := n.tree.Watch(path, c, dummyDoNotWatch, events...); err != nil {
 		n.t.Errorf("Watch(%s, %p, %v)=%v", path, c, events, err)
 	}
 }
 
 func (n *N) WatchErr(path string, c chan<- EventInfo, err error, events ...Event) {
 	path = filepath.Join(n.w.root, path)
-	switch e := n.tree.Watch(path, c, events...); {
+	switch e := n.tree.Watch(path, c, dummyDoNotWatch, events...); {
 	case err == nil && e == nil:
 		n.t.Errorf("Watch(%s, %p, %v)=nil", path, c, events)
 	case err != nil && e != err:

--- a/vendor/github.com/zillode/notify/tree.go
+++ b/vendor/github.com/zillode/notify/tree.go
@@ -7,7 +7,7 @@ package notify
 const buffer = 128
 
 type tree interface {
-	Watch(string, chan<- EventInfo, ...Event) error
+	Watch(string, chan<- EventInfo, func(string) bool, ...Event) error
 	Stop(chan<- EventInfo)
 	Close() error
 }

--- a/vendor/github.com/zillode/notify/tree_recursive.go
+++ b/vendor/github.com/zillode/notify/tree_recursive.go
@@ -153,7 +153,8 @@ func (t *recursiveTree) dispatch() {
 }
 
 // Watch TODO(rjeczalik)
-func (t *recursiveTree) Watch(path string, c chan<- EventInfo, events ...Event) error {
+func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
+	doNotWatch func(string) bool, events ...Event) error {
 	if c == nil {
 		panic("notify: Watch using nil channel")
 	}

--- a/vendor/github.com/zillode/notify/watcher_fsevents.go
+++ b/vendor/github.com/zillode/notify/watcher_fsevents.go
@@ -133,7 +133,7 @@ func (w *watch) Dispatch(ev []FSEvent) {
 			ev[i].Flags, ev[i].Path, i, ev[i].ID, len(ev))
 		if ev[i].Flags&failure != 0 {
 			// TODO(rjeczalik): missing error handling
-			panic("unhandled error: " + Event(ev[i].Flags).String())
+			continue
 		}
 		if !strings.HasPrefix(ev[i].Path, w.path) {
 			continue

--- a/vendor/github.com/zillode/notify/watcher_readdcw.go
+++ b/vendor/github.com/zillode/notify/watcher_readdcw.go
@@ -377,7 +377,7 @@ func (r *readdcw) loopevent(n uint32, overEx *overlappedEx) {
 	var currOffset uint32
 	for {
 		raw := (*syscall.FileNotifyInformation)(unsafe.Pointer(&overEx.parent.buffer[currOffset]))
-		name := syscall.UTF16ToString((*[syscall.MAX_PATH]uint16)(unsafe.Pointer(&raw.FileName))[:raw.FileNameLength>>1])
+		name := syscall.UTF16ToString((*[syscall.MAX_LONG_PATH]uint16)(unsafe.Pointer(&raw.FileName))[:raw.FileNameLength>>1])
 		events = append(events, &event{
 			pathw:  overEx.parent.pathw,
 			filter: overEx.parent.filter,

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -302,7 +302,7 @@
 		{
 			"importpath": "github.com/zillode/notify",
 			"repository": "https://github.com/zillode/notify",
-			"revision": "921f2bc094bff902bf6089603902a84ac988d351",
+			"revision": "df33c1a773b462f936a149c36696c018c047eaa9",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
The notify library is rather outdated and has one significant drawback: Watches are installed on all files, also the ignored ones. With this update watches not installed on files that are ignored.