### PR TITLE
Add Stop() and adopt logging scheme from rwfolder.go

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -186,6 +186,7 @@ func (f *sendReceiveFolder) Serve() {
 	for {
 		select {
 		case <-f.stop:
+			fsWatcher.Stop()
 			return
 
 		case <-f.remoteIndex:


### PR DESCRIPTION
The `Stop()` method terminates the infinite for loop and releases FS watches by stopping the notify backend.

Logging with folder information prefix is changed to the way it is done in rwfolder.go. This allows to use different log levels.